### PR TITLE
Compilation speedup

### DIFF
--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -3004,8 +3004,8 @@ build/genhooks.o : genhooks.cc $(TARGET_DEF) $(C_TARGET_DEF)		\
   $(COMMON_TARGET_DEF) $(D_TARGET_DEF) $(BCONFIG_H) $(SYSTEM_H) errors.h
 build/genmddump.o : genmddump.cc $(RTL_BASE_H) $(BCONFIG_H) $(SYSTEM_H)	\
   $(CORETYPES_H) $(GTM_H) errors.h $(READ_MD_H) $(GENSUPPORT_H)
-build/genmatch.o : genmatch.cc $(BCONFIG_H) $(SYSTEM_H) \
-  $(CORETYPES_H) errors.h $(HASH_TABLE_H) hash-map.h $(GGC_H) is-a.h \
+build/genmatch.o : genmatch.cc $(BCONFIG_H) $(SYSTEM_H) $(CORETYPES_H) \
+  errors.h $(HASH_TABLE_H) hash-map.h $(GGC_H) is-a.h ordered-hash-map.h \
   tree.def builtins.def internal-fn.def case-cfn-macros.h $(CPPLIB_H)
 build/gencfn-macros.o : gencfn-macros.cc $(BCONFIG_H) $(SYSTEM_H)	\
   $(CORETYPES_H) errors.h $(HASH_TABLE_H) hash-set.h builtins.def	\

--- a/gcc/genmatch.cc
+++ b/gcc/genmatch.cc
@@ -29,6 +29,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "hash-table.h"
 #include "hash-set.h"
 #include "is-a.h"
+#include "ordered-hash-map.h"
 
 
 /* Stubs for GGC referenced through instantiations triggered by hash-map.  */
@@ -1684,7 +1685,7 @@ struct sinfo_hashmap_traits : simple_hashmap_traits<pointer_hash<dt_simplify>,
   template <typename T> static inline void remove (T &) {}
 };
 
-typedef hash_map<void * /* unused */, sinfo *, sinfo_hashmap_traits>
+typedef ordered_hash_map<void * /* unused */, sinfo *, sinfo_hashmap_traits>
   sinfo_map_t;
 
 /* Current simplifier ID we are processing during insertion into the

--- a/gcc/genmatch.cc
+++ b/gcc/genmatch.cc
@@ -217,9 +217,56 @@ fp_decl_done (FILE *f, const char *trailer)
     fprintf (header_file, "%s;", trailer);
 }
 
+/* Line numbers for use by indirect line directives.  */
+static vec<int> dbg_line_numbers;
+
+static void
+write_header_declarations (bool gimple, FILE *f)
+{
+  fprintf (f, "\nextern void\n%s_dump_logs (const char *file1, int line1_id, "
+	      "const char *file2, int line2, bool simplify);\n",
+	      gimple ? "gimple" : "generic");
+}
+
+static void
+define_dbg_line_numbers (bool gimple, FILE *f)
+{
+
+  if (dbg_line_numbers.is_empty ())
+    {
+      fprintf (f, "};\n\n");
+      return;
+    }
+
+  fprintf (f , "void\n%s_dump_logs (const char *file1, int line1_id,"
+		"const char *file2, int line2, bool simplify)\n{\n",
+		gimple ? "gimple" : "generic");
+
+  fprintf_indent (f, 2, "static int __dbg_line_numbers[%d] = {",
+		  dbg_line_numbers.length ());
+
+  for (int i = 0; i < (int)dbg_line_numbers.length () - 1; i++)
+    {
+      if (i % 20 == 0)
+	fprintf (f, "\n\t");
+
+      fprintf (f, "%d, ", dbg_line_numbers[i]);
+    }
+  fprintf (f, "%d\n  };\n\n", dbg_line_numbers.last ());
+
+
+  fprintf_indent (f, 2, "fprintf (dump_file, \"%%s "
+		  "%%s: __dbg_line_numbers[%%d], %%s:%%d\\n\",\n");
+  fprintf_indent (f, 10, "simplify ? \"Applying pattern\" : "
+		  "\"Matching expression\", file1, line1_id, file2, line2);");
+
+  fprintf (f, "\n}\n\n");
+}
+
 static void
 output_line_directive (FILE *f, location_t location,
-		       bool dumpfile = false, bool fnargs = false)
+		      bool dumpfile = false, bool fnargs = false,
+		      bool indirect_line_numbers = false)
 {
   const line_map_ordinary *map;
   linemap_resolve_location (line_table, location, LRK_SPELLING_LOCATION, &map);
@@ -239,7 +286,15 @@ output_line_directive (FILE *f, location_t location,
 	++file;
 
       if (fnargs)
-	fprintf (f, "\"%s\", %d", file, loc.line);
+  {
+  if (indirect_line_numbers)
+    {
+      fprintf (f, "\"%s\", %d", file, dbg_line_numbers.length ());
+      dbg_line_numbers.safe_push (loc.line);
+    }
+  else
+    fprintf (f, "\"%s\", %d", file, loc.line);
+  }
       else
 	fprintf (f, "%s:%d", file, loc.line);
     }
@@ -3375,20 +3430,19 @@ dt_operand::gen (FILE *f, int indent, bool gimple, int depth)
     }
 }
 
-/* Emit a fprintf to the debug file to the file F, with the INDENT from
+/* Emit a logging call to the debug file to the file F, with the INDENT from
    either the RESULT location or the S's match location if RESULT is null. */
 static void
-emit_debug_printf (FILE *f, int indent, class simplify *s, operand *result)
+emit_logging_call (FILE *f, int indent, class simplify *s, operand *result,
+				  bool gimple)
 {
   fprintf_indent (f, indent, "if (UNLIKELY (debug_dump)) "
-	   "fprintf (dump_file, \"%s ",
-	   s->kind == simplify::SIMPLIFY
-	   ? "Applying pattern" : "Matching expression");
-  fprintf (f, "%%s:%%d, %%s:%%d\\n\", ");
+	   "%s_dump_logs (", gimple ? "gimple" : "generic");
   output_line_directive (f,
-			 result ? result->location : s->match->location, true,
-			 true);
-  fprintf (f, ", __FILE__, __LINE__);\n");
+			result ? result->location : s->match->location,
+			true, true, true);
+  fprintf (f, ", __FILE__, __LINE__, %s);\n",
+	      s->kind == simplify::SIMPLIFY ? "true" : "false");
 }
 
 /* Generate code for the '(if ...)', '(with ..)' and actual transform
@@ -3524,7 +3578,7 @@ dt_simplify::gen_1 (FILE *f, int indent, bool gimple, operand *result)
   if (!result)
     {
       /* If there is no result then this is a predicate implementation.  */
-      emit_debug_printf (f, indent, s, result);
+      emit_logging_call (f, indent, s, result, gimple);
       fprintf_indent (f, indent, "return true;\n");
     }
   else if (gimple)
@@ -3615,7 +3669,7 @@ dt_simplify::gen_1 (FILE *f, int indent, bool gimple, operand *result)
 	}
       else
 	gcc_unreachable ();
-      emit_debug_printf (f, indent, s, result);
+      emit_logging_call (f, indent, s, result, gimple);
       fprintf_indent (f, indent, "return true;\n");
     }
   else /* GENERIC */
@@ -3670,7 +3724,7 @@ dt_simplify::gen_1 (FILE *f, int indent, bool gimple, operand *result)
 	    }
 	  if (is_predicate)
 	    {
-	      emit_debug_printf (f, indent, s, result);
+	      emit_logging_call (f, indent, s, result, gimple);
 	      fprintf_indent (f, indent, "return true;\n");
 	    }
 	  else
@@ -3738,7 +3792,7 @@ dt_simplify::gen_1 (FILE *f, int indent, bool gimple, operand *result)
 				  i);
 		}
 	    }
-	  emit_debug_printf (f, indent, s, result);
+	  emit_logging_call (f, indent, s, result, gimple);
 	  fprintf_indent (f, indent, "return _r;\n");
 	}
     }
@@ -5447,6 +5501,7 @@ main (int argc, char **argv)
       parts.quick_push (stdout);
       write_header (stdout, s_include_file);
       write_header_includes (gimple, stdout);
+      write_header_declarations (gimple, stdout);
     }
   else
     {
@@ -5460,6 +5515,7 @@ main (int argc, char **argv)
       fprintf (header_file, "#ifndef GCC_GIMPLE_MATCH_AUTO_H\n"
 			    "#define GCC_GIMPLE_MATCH_AUTO_H\n");
       write_header_includes (gimple, header_file);
+      write_header_declarations (gimple, header_file);
     }
 
   /* Go over all predicates defined with patterns and perform
@@ -5501,6 +5557,8 @@ main (int argc, char **argv)
     dt.print (stderr);
 
   dt.gen (parts, gimple);
+
+  define_dbg_line_numbers (gimple, choose_output (parts));
 
   for (FILE *f : parts)
     {

--- a/gcc/ordered-hash-map-tests.cc
+++ b/gcc/ordered-hash-map-tests.cc
@@ -58,6 +58,7 @@ static void
 test_map_of_strings_to_int ()
 {
   ordered_hash_map <const char *, int> m;
+  bool existed;
 
   const char *ostrich = "ostrich";
   const char *elephant = "elephant";
@@ -74,9 +75,13 @@ test_map_of_strings_to_int ()
   ASSERT_EQ (false, m.put (ostrich, 2));
   ASSERT_EQ (false, m.put (elephant, 4));
   ASSERT_EQ (false, m.put (ant, 6));
-  ASSERT_EQ (false, m.put (spider, 8));
+  existed = true;
+  int &value = m.get_or_insert (spider, &existed);
+  value = 8;
+  ASSERT_EQ (false, existed);
   ASSERT_EQ (false, m.put (millipede, 750));
   ASSERT_EQ (false, m.put (eric, 3));
+
 
   /* Verify that we can recover the stored values.  */
   ASSERT_EQ (6, m.elements ());
@@ -84,7 +89,9 @@ test_map_of_strings_to_int ()
   ASSERT_EQ (4, *m.get (elephant));
   ASSERT_EQ (6, *m.get (ant));
   ASSERT_EQ (8, *m.get (spider));
-  ASSERT_EQ (750, *m.get (millipede));
+  existed = false;
+  ASSERT_EQ (750, m.get_or_insert (millipede, &existed));
+  ASSERT_EQ (true, existed);
   ASSERT_EQ (3, *m.get (eric));
 
   /* Verify that the order of insertion is preserved.  */
@@ -113,6 +120,7 @@ test_map_of_int_to_strings ()
 {
   const int EMPTY = -1;
   const int DELETED = -2;
+  bool existed;
   typedef int_hash <int, EMPTY, DELETED> int_hash_t;
   ordered_hash_map <int_hash_t, const char *> m;
 
@@ -131,7 +139,9 @@ test_map_of_int_to_strings ()
   ASSERT_EQ (false, m.put (2, ostrich));
   ASSERT_EQ (false, m.put (4, elephant));
   ASSERT_EQ (false, m.put (6, ant));
-  ASSERT_EQ (false, m.put (8, spider));
+  const char* &value = m.get_or_insert (8, &existed);
+  value = spider;
+  ASSERT_EQ (false, existed);
   ASSERT_EQ (false, m.put (750, millipede));
   ASSERT_EQ (false, m.put (3, eric));
 
@@ -141,7 +151,8 @@ test_map_of_int_to_strings ()
   ASSERT_EQ (*m.get (4), elephant);
   ASSERT_EQ (*m.get (6), ant);
   ASSERT_EQ (*m.get (8), spider);
-  ASSERT_EQ (*m.get (750), millipede);
+  ASSERT_EQ (m.get_or_insert (750, &existed), millipede);
+  ASSERT_EQ (existed, TRUE);
   ASSERT_EQ (*m.get (3), eric);
 
   /* Verify that the order of insertion is preserved.  */

--- a/gcc/ordered-hash-map.h
+++ b/gcc/ordered-hash-map.h
@@ -76,6 +76,32 @@ public:
     return m_map.get (k);
   }
 
+  /* Return a reference to the value for the passed in key, creating the entry
+    if it doesn't already exist.  If existed is not NULL then it is set to
+    false if the key was not previously in the map, and true otherwise.  */
+
+  Value &get_or_insert (const Key &k, bool *existed = NULL)
+  {
+    bool _existed;
+    Value &ret = m_map.get_or_insert (k, &_existed);
+
+    if (!_existed)
+      {
+	bool key_present;
+	int &slot = m_key_index.get_or_insert (k, &key_present);
+	if (!key_present)
+	  {
+	    slot = m_keys.length ();
+	    m_keys.safe_push (k);
+	  }
+      }
+
+    if (existed)
+      *existed = _existed;
+
+    return ret;
+  }
+
   /* Removing a key removes it from the map, but retains the insertion
      order.  */
 


### PR DESCRIPTION
This PR makes it faster to rebuild gcc after editing the match.pb by reducing variability in the code generation process.